### PR TITLE
Prevent UnboundLocalError when filtering=False

### DIFF
--- a/codes/python/WaLSAtools/analysis_modules/WaLSA_k_omega.py
+++ b/codes/python/WaLSAtools/analysis_modules/WaLSA_k_omega.py
@@ -436,6 +436,7 @@ def WaLSA_k_omega(signal, time=None, **kwargs):
     temporal_fft = None
     temporal_frequencies = None
     spatial_frequencies = None
+    temporal_filter = None
 
     # Check and adjust format if necessary
     if params['format'] == 'xyt':


### PR DESCRIPTION
The return requires temporal_filter which is not fixed at the beginning of the function.